### PR TITLE
sql: Update transaction-model.md

### DIFF
--- a/sql/transaction-model.md
+++ b/sql/transaction-model.md
@@ -12,7 +12,7 @@ Similarly, functions such as `GET_LOCK()` and `RELEASE_LOCK()` and statements su
 
 **Note:** On the business side, remember to check the returned results of `commit` because even there is no error in the execution, there might be errors in the `commit` process.
 
-## Behavior and performance differences
+## Differences from MySQL
 
 ### Transaction retry
 


### PR DESCRIPTION
This page was previously called "transactions: mysql compatibility".  Because that was dropped the differences heading makes less sense.. differences from what?

Updating the sub-heading to be differences from MySQL.
